### PR TITLE
Update MailgunSwiftTransport.php

### DIFF
--- a/src/MailgunSwiftTransport.php
+++ b/src/MailgunSwiftTransport.php
@@ -364,9 +364,6 @@ class MailgunSwiftTransport implements Swift_Transport
             if ($primaryEmail === null) {
                 $primaryEmail = $toEmail;
             }
-            if (!$toName) {
-                $toName = $toEmail;
-            }
             if ($toName) {
                 $recipients[] = sprintf('%s <%s>', $toName, $toEmail);
             } else {


### PR DESCRIPTION
Removed the code that automatically assigns a name, as if this causes the next if statement to always succeed. It also incorrectly formats the to address string when sending to multiple emails