### PR TITLE
fix: check general canView first

### DIFF
--- a/src/MailgunAdmin.php
+++ b/src/MailgunAdmin.php
@@ -629,6 +629,10 @@ class MailgunAdmin extends LeftAndMain implements PermissionProvider
      */
     public function canView($member = null)
     {
+        if(!parent::canView($member)) {
+            return false;
+        }
+        
         $mailer = MailgunHelper::getMailer();
         // Another custom mailer has been set
         if (!$mailer instanceof SwiftMailer) {


### PR DESCRIPTION
`LeftAndMain::canView()` allows extensions to prohibit the admin section to appear through `alternateAccessCheck` hook.

Here I propose to perform the default checks first and then use the custom ones.